### PR TITLE
Fix autostart.sh to work with batocera

### DIFF
--- a/system/autostart.sh
+++ b/system/autostart.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # startup script for a dedicated Pi for Pixelcade, systemd calls this via /etc/systemd/system/pixelcade.service
+PIXELHOME=$HOME/pixelcade
+PATH=$PIXELHOME/jdk/bin:$PATH
 
-cd /home/pi/pixelcade && java -jar pixelweb.jar -b &
+cd $PIXELHOME && java -jar pixelweb.jar -b &
 sleep 10 && curl localhost:8080/arcade/stream/mame/pixelcade
 #sleep 10 && cd /home/pi/pixelcade/system && ./pixelcade-startup.sh


### PR DESCRIPTION
Pixelcade for batocera is installed to a different homedir. Pixelcade should use $HOME instead of hardcoded paths.

In batocera, JDK is installed to $HOME/pixelcade/jdk so adding that to the path so java can be called.